### PR TITLE
Ayana/add page

### DIFF
--- a/frontend/src/apis/generated/models/CreateTaskReqDTO.ts
+++ b/frontend/src/apis/generated/models/CreateTaskReqDTO.ts
@@ -8,6 +8,7 @@ export type CreateTaskReqDTO = {
     message_id?: (string | null);
     due_date?: (string | null);
     group_id: string;
+    labels: Array<string>;
     assigned_user_ids: Array<string>;
 };
 

--- a/frontend/src/components/TaskItem.vue
+++ b/frontend/src/components/TaskItem.vue
@@ -16,7 +16,7 @@ defineProps<Props>()
     <div class="task-title">{{ task.title }}</div>
 
     <div class="task-details">
-      <p>期日：2024年6月15日</p>
+      <p>期日：{{ task.due_date }}</p>
       <!-- 詳細を表示のテキストを追加 -->
       <div v-if="openDetail == false" class="additional-details">
         <button class="detail-button" @click="openDetail = !openDetail">詳細を表示</button>

--- a/frontend/src/views/TaskAdd.vue
+++ b/frontend/src/views/TaskAdd.vue
@@ -22,9 +22,9 @@ const datePickerDisplay = ref(false)
 const newTask = ref<CreateTaskReqDTO>({
   title: 'string',
   content: 'string',
-  due_date: 'string',
+  due_date: '',
   group_id: 'string',
-  // labels: [],
+  labels: [],
   assigned_user_ids: []
 })
 
@@ -34,15 +34,16 @@ const openDatePicker = () => {
 
 const createTask = () => {
   apiClient.default.createTaskTasksPost(newTask.value).catch((v) => console.log(v))
-
+//値を追加？
   newTask.value = {
     title: '',
     content: '',
     due_date: '',
     group_id: '',
-    // labels: [],
+    labels: [],
     assigned_user_ids: []
   }
+
 }
 </script>
 
@@ -52,9 +53,11 @@ const createTask = () => {
     <PageContainer>
       <div class="field">
         <v-row class="justify-end">
-          <v-btn icon variant="flat">
+          <router-link :to="{ name: 'TaskList' }">
+           <v-btn icon variant="flat">
             <v-icon>mdi-close-circle-outline</v-icon>
           </v-btn>
+        </router-link>
         </v-row>
         <v-text-field v-model="newTask.title" label="タスク名" clearable />
         <v-text-field v-model="newTask.assigned_user_ids" label="アサイン先(@で指定)" clearable />
@@ -67,11 +70,13 @@ const createTask = () => {
           <v-date-picker v-if="datePickerDisplay === true"></v-date-picker>
         </v-text-field>
         <v-textarea rows="5" v-model="newTask.content" label="内容" clearable />
-        <v-combobox v-model="newTask.assigned_user_ids" chips multiple label="ラベル" clearable />
+        <v-combobox v-model="newTask.labels" chips multiple label="ラベル" clearable />
         <v-row class="justify-center">
+          <router-link :to="{ name: 'TaskList' }">
           <div @click="createTask">
             <PrimaryButton text="作成" />
           </div>
+          </router-link>
         </v-row>
       </div>
     </PageContainer>

--- a/frontend/src/views/TaskAdd.vue
+++ b/frontend/src/views/TaskAdd.vue
@@ -20,10 +20,10 @@ apiClient.default.getUserUsersMeGet().then((res) => (user.value = res))
 const datePickerDisplay = ref(false)
 
 const newTask = ref<CreateTaskReqDTO>({
-  title: 'string',
-  content: 'string',
+  title: '',
+  content: '',
   due_date: '',
-  group_id: 'string',
+  group_id: '',
   labels: [],
   assigned_user_ids: []
 })

--- a/frontend/src/views/TaskList.vue
+++ b/frontend/src/views/TaskList.vue
@@ -75,8 +75,8 @@ const tasks = ref<TaskDetails[]>([
     <PageContainer>
       <div style="display: flex">
         <h2>{{ selectedGroup }}</h2>
-        <button>自分のタスク</button>
-        <button>タグ</button>
+        <button class = "tag">自分のタスク</button>
+        <button class = "tag">タグ</button>
         <router-link :to="{ name: 'TaskAdd' }">
           <PrimaryButton text="新規タスクを追加" />
         </router-link>
@@ -133,4 +133,20 @@ const tasks = ref<TaskDetails[]>([
     list-style-type: none; /* 中黒を消す */
   }
 }
+
+.tag {
+  display: inline-block;
+  padding: 8px 16px; /* ボタンの内側の余白 */
+  border: 1px solid #ccc; /* 灰色の枠線 */
+  border-radius: 30px; /* 角丸の大きさ */
+  background-color: #f9f9f9; /* ボタンの背景色 */
+  color: #333; /* テキストの色 */
+  text-align: center;
+  cursor: pointer;
+}
+
+.tag:hover {
+  background-color: #e6e6e6; /* ホバー時の背景色 */
+}
+
 </style>

--- a/frontend/src/views/TaskList.vue
+++ b/frontend/src/views/TaskList.vue
@@ -35,7 +35,7 @@ const tasks = ref<TaskDetails[]>([
     title: 'タイトル',
     content: '内容',
     message_id: '',
-    due_date: '6月15日',
+    due_date: '6月16日',
     id: '',
     group_id: '',
     created_at: '',


### PR DESCRIPTION
他の部分うまくいかなかったのでとりあえず直せたところだけ上げさせていただきます

変更点：
・期日を直打ちから日付部分のみ一応配列から取ってくるように
・TaskAddViewでばつボタンと作成ボタンを押した時に画面遷移するように

TaskAddViewでできなかった/できてない点：
・カレンダーで選択した日付をテキストフィールドに表示
・タスク作成時に、入力値をNewTaskに代入??→タスク追加

※追記
・カレンダー表示した際に「期日」という文字が前面に出たまま